### PR TITLE
fix: display completed tasks with strikethrough instead of removing them

### DIFF
--- a/services/todoService.ts
+++ b/services/todoService.ts
@@ -143,7 +143,6 @@ class TodoService {
     const tasks = this.getTasks();
     const today = new Date().toISOString().split('T')[0];
     return tasks.filter(task => 
-      !task.completed && 
       task.dueDate && 
       task.dueDate.startsWith(today)
     );
@@ -154,7 +153,6 @@ class TodoService {
     const tasks = this.getTasks();
     const today = new Date();
     return tasks.filter(task => 
-      !task.completed && 
       task.dueDate && 
       new Date(task.dueDate) > today
     );


### PR DESCRIPTION
Fixes #1

Completed tasks are now displayed with strikethrough styling instead of being automatically removed from the Today and Upcoming views.

## Changes
- Removed completed task filter from `getTodayTasks()` method
- Removed completed task filter from `getUpcomingTasks()` method
- List views already showed completed tasks correctly

Generated with [Claude Code](https://claude.ai/code)