### PR TITLE
feat: change navigation bar title from "Menu" to "oToDo"

### DIFF
--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -60,7 +60,7 @@ export default function Sidebar({
     <div className="w-64 bg-gray-50 h-screen flex flex-col border-r border-gray-200">
       {/* Header */}
       <div className="p-4 flex items-center justify-between border-b border-gray-200">
-        <h1 className="text-xl font-semibold">Menu</h1>
+        <h1 className="text-xl font-semibold">oToDo</h1>
         <button onClick={onToggleCollapse} className="p-1 hover:bg-gray-200 rounded">
           <MenuIcon className="w-5 h-5" />
         </button>


### PR DESCRIPTION
Fixes #4

Changes the navigation bar title from "Menu" to "oToDo" as requested in the issue.

## Changes
- Updated the sidebar header title in `components/layout/Sidebar.tsx`

Generated with [Claude Code](https://claude.ai/code)